### PR TITLE
Fixed require error

### DIFF
--- a/find_me_a_sandwich/.rspec
+++ b/find_me_a_sandwich/.rspec
@@ -1,2 +1,1 @@
 --color
---require spec_helper

--- a/find_me_a_sandwich/spec/rails_helper.rb
+++ b/find_me_a_sandwich/spec/rails_helper.rb
@@ -9,12 +9,12 @@ unless zeus_running?
   SimpleCov.start("rails")
 end
 
-require "rspec/rails"
+require "rails/all"
 require "webmock/rspec"
 require "database_cleaner"
-require "vcr"
 require "spec_helper"
 require File.expand_path("../../config/environment", __FILE__)
+require "rspec/rails"
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|

--- a/find_me_a_sandwich/spec/spec_helper.rb
+++ b/find_me_a_sandwich/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "vcr"
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Gem 'vcr' would not be loaded when running `bundle exec rspec`.

Both `bundle exec` and `zeus` now work with this app.
